### PR TITLE
add_scrolleable_fix_sanitizer

### DIFF
--- a/server/views/layouts/main.hbs
+++ b/server/views/layouts/main.hbs
@@ -395,7 +395,7 @@
               '</div><div class="divTableCell spkn" id="' +
               id +
               '">' +
-              value +
+              doubleSanitizer(value) +
               "</div></div>";
           }
         }


### PR DESCRIPTION
Senintegra la corrección y sanitización de las letras itálicas en la sección escroleable del visualizador de eafs de Sylard propuesto por @lokimenethill .