### PR TITLE
se reparó el boton submit

### DIFF
--- a/server/locales/en.json
+++ b/server/locales/en.json
@@ -88,6 +88,8 @@
         "OPEN_BOX":"Tell us why you want a Contributor account.",
         "ALERT_PRIV":"At the moment the administrator is checking your reasons about your change of account to contributor"
     },
+    "restore":"Reset"
+    ,
     "RESETPASSWORD": {
         "RESET_PASSWORD_TITLE": "Reset Password",
         "TYPE_EMAIL": "Type your email!",

--- a/server/locales/es.json
+++ b/server/locales/es.json
@@ -88,6 +88,8 @@
         "OPEN_BOX":"Indique porque desea una cuenta de Contribuyente",
         "ALERT_PRIV":"En estos momentos el administrador revisa los motivos por los cuales quiere cambiar tu tipo de cuenta a colaborador"
     },
+    "restore":"Restablecer"
+    ,
     "RESETPASSWORD": {
         "RESET_PASSWORD_TITLE": "Restablecer contraseña",
         "TYPE_EMAIL": "¡Escríbe tu correo!",

--- a/server/views/audioannotations/create.hbs
+++ b/server/views/audioannotations/create.hbs
@@ -152,7 +152,7 @@
         <div class="botones_agregar_audioanotacion">
             <div class="contenedor_botones">
               <button type="reset" class="btn btn-secundario"
-                  id="boton_restablecer_agregar_audioanotacion">{{translation.RESETPASSWORD.SUBMIT}}</button>
+                  id="boton_restablecer_agregar_audioanotacion">{{translation.restore}}</button>
               <button type="submit" class="btn btn-primario"
                   id="boton_guardar_agregar_audioanotacion">{{translation.SYLARDCOLLECTIONS.SAVE}}</button>
             </div>


### PR DESCRIPTION
El error se encontró en la [ruta](https://github.com/rivalcoba/sylard00/blob/master/server/views/audioannotations/create.hbs) server\views\audioannotations\create.hbs  en la línea 155 en el archivo create.hbs donde pertenece el ID ="boton_restablecer_agregar_audioanotacion"  el problema estaba que el botón llamado submit estaba tomado el nombre de un botón que ya estaba en uso como en la imagen
![2022-04-24_17h05_08](https://user-images.githubusercontent.com/93813510/164999498-469b9af7-2beb-41ed-8e79-7cf8be1726a0.png)
 la solución fue crearle una nueva ruta donde lea la parte del archivo "es.json" y "en.json" donde se procedió a crearle el nombre de ("restore":"Restablecer") en el archivo "en.json" y  ("restore":"Reset") en el archivo "en.json" 

![2022-04-24_17h07_09](https://user-images.githubusercontent.com/93813510/165000130-4104fda5-1fd2-4409-9669-785eeb44ba67.png)
donde "restore" va a ser leído por el servidor y "Reset" será leído por el cliente, visualizándolo "Reset" dentro del botón


![2022-04-24_17h53_59](https://user-images.githubusercontent.com/93813510/165000195-9db08b3a-1d23-4462-b15e-b63ea069ab76.png)

